### PR TITLE
For files smaller than the minimum size required for file type

### DIFF
--- a/lib/joystream/core/repository.js
+++ b/lib/joystream/core/repository.js
@@ -33,6 +33,8 @@ const fswalk = require('joystream/util/fs/walk');
 
 const CHUNK_SIZE = 64 * 1024;
 
+const DEFAULT_FILE_TYPE = 'application/octet-stream';
+
 
 /*
  * Repository class; abstracts out file system and hyperdrive based backends.
@@ -185,6 +187,26 @@ class Repository extends events.EventEmitter
 
         // Have a reader function that detects the file type.
         var buf = Buffer.alloc(0);
+        const invoke_callback = (mime_type) => {
+          // Now put the detection buffer into a readable memory stream,
+          // pass that on, and 'pipe' to it.
+          console.log(stream.readableHighWaterMark);
+          const bufstream = new ReadableStreamBuffer({
+            chunkSize: CHUNK_SIZE,
+          });
+          bufstream.put(buf);
+
+          cb(null, mime_type, bufstream);
+
+          stream.on('data', (data) => {
+            bufstream.put(data);
+          });
+          stream.on('end', (data) => {
+            bufstream.put(data);
+            bufstream.stop();
+          });
+        };
+
         const ft_detector = (chunk) => {
           // Ensure chunk is a Buffer
           if (typeof chunk === 'string') {
@@ -198,42 +220,48 @@ class Repository extends events.EventEmitter
           // If we have sufficient data buffered, detect file type.
           if (buf.length >= file_type.minimumBytes) {
             stream.off('data', ft_detector);
+            stream.off('end', ft_detector_end);
 
             debug('Read enough for file type detection.');
-            var ft = { mime: 'application/octet-stream' };
+            var ft = { mime: DEFAULT_FILE_TYPE };
             const res = file_type(buf);
             if (res != null) {
               ft = res;
             }
             debug('File type detected as', ft.mime);
 
-            // Now put the detection buffer into a readable memory stream,
-            // pass that on, and 'pipe' to it.
-            console.log(stream.readableHighWaterMark);
-            const bufstream = new ReadableStreamBuffer({
-              chunkSize: CHUNK_SIZE,
-            });
-            bufstream.put(buf);
-
-            cb(null, ft.mime, bufstream);
-
-            stream.on('data', (data) => {
-              bufstream.put(data);
-            });
-            stream.on('end', (data) => {
-              bufstream.put(data);
-              bufstream.stop();
-            });
+            invoke_callback(ft.mime);
+            return true;
           }
+          return false;
+        };
+
+        const ft_detector_end = (chunk) => {
+          // This is called if the stream reaches an end without having
+          // detected a file type.
+          // Give one last attempt to detect the file type. If that worked,
+          // the callback will have been invoked.
+          if (chunk) {
+            if (ft_detector(chunk)) {
+              return;
+            }
+          }
+
+          // If we didn't return above, we need to invoke the callback
+          // still, but won't know the mime type.
+          stream.off('data', ft_detector);
+          stream.off('end', ft_detector_end);
+          invoke_callback(null);
         };
 
         stream.on('data', ft_detector);
+        stream.on('end', ft_detector_end);
         return;
       }
       else {
         const stream = this.archive.createWriteStream(fname, { flags: `${mode}+`,
           encoding: 'binary' });
-        return cb(null, null, stream);
+        return cb(null, DEFAULT_FILE_TYPE, stream);
       }
     } catch (err) {
       return cb(err);


### PR DESCRIPTION
detection, reading a file would never yield data since the fix for #35.
Fixed that.