### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:10-alpine AS builder
+
+RUN apk add --update --no-cache bash libtool git build-base autoconf automake python2 \
+    && npm install -g yarn
+WORKDIR /storage-node
+COPY . /storage-node
+RUN yarn run build
+
+FROM node:10-alpine
+WORKDIR /storage-node
+COPY --from=builder /storage-node /storage-node
+ENTRYPOINT [ "/storage-node/bin/cli.js" ]


### PR DESCRIPTION
This PR adds a `Dockerfile` to build Docker images.

### Building

```
$ docker build -t joystream/storage-node .
```

### Running

```
$ docker run --rm joystream/storage-node <COMMAND>
```
i.e.:
```
$ docker run --rm joystream/storage-node --help
```

**Note:** when running a Docker container, its filesystem is separate from the host's. To pass the host files you can use [-v flag](https://docs.docker.com/engine/reference/commandline/run/#mount-volume--v---read-only).

---
**Joystream address:** `5GxcUjY3tXYaDnm6LDu3yRdgE9wACXbmqjYVVAg8FwRZYPmF`