### PR TITLE
Handle Ready status not emitted in signAndSend()

### DIFF
--- a/packages/runtime-api/discovery.js
+++ b/packages/runtime-api/discovery.js
@@ -43,9 +43,8 @@ class DiscoveryApi
   async setAccountInfo(accountId, ipnsId, ttl) {
     const isActor = await this.base.identities.isActor(accountId)
     if (isActor) {
-      const decoded = this.base.identities.keyring.decodeAddress(accountId, true)
       const tx = this.base.api.tx.discovery.setIpnsId(ipnsId, ttl)
-      return this.base.signAndSend(decoded, tx)
+      return this.base.signAndSend(accountId, tx)
     } else {
       throw new Error('Cannot set AccountInfo for non actor account')
     }

--- a/packages/runtime-api/index.js
+++ b/packages/runtime-api/index.js
@@ -267,6 +267,7 @@ class RuntimeApi
 
             // releases lock
             reject(err);
+            finalizedPromise.reject(err);
           });
       });
     })


### PR DESCRIPTION
This fixes blocked call to signAndSend() when the Ready status doesn't occur.

I don't know why on some occasions it is not emitted. Will have to find some docs about the life-cycle of a tx when submitted over RPC to a subtrate node.

This fixes one issue discovered when testing signup process with @bwhm
