### PR TITLE
discovery and sync - various fixes

### DIFF
--- a/packages/colossus/lib/sync.js
+++ b/packages/colossus/lib/sync.js
@@ -100,7 +100,7 @@ async function sync_periodic(api, config, storage)
 
 function start_syncing(api, config, storage)
 {
-  setTimeout(sync_periodic, config.get('syncPeriod'), api, config, storage);
+  sync_periodic(api, config, storage);
 }
 
 module.exports = {

--- a/packages/discovery/publish.js
+++ b/packages/discovery/publish.js
@@ -1,8 +1,7 @@
 const ipfsClient = require('ipfs-http-client')
 const debug = require('debug')('discovery::publish')
 
-const SERVICES_KEY_NAME = 'services'
-const DEFAULT_LIFETIME = 14400 // Service key shouldn't change very often
+const SERVICES_KEY_NAME = 'services';
 
 function bufferFrom(data) {
     return Buffer.from(JSON.stringify(data), 'utf-8')
@@ -15,13 +14,7 @@ function encodeServiceInfo(info) {
     })
 }
 
-async function publish (accountId, service_info, runtimeApi) {
-    let isActor = await runtimeApi.identities.isActor(accountId)
-
-    if (!isActor) {
-        throw new Error('Non actor account cannot publish service info')
-    }
-
+async function publish (service_info) {
     const ipfs = ipfsClient('localhost', '5001', { protocol: 'http' })
 
     const keys = await ipfs.key.list()
@@ -48,25 +41,7 @@ async function publish (accountId, service_info, runtimeApi) {
     })
 
     debug(published)
-
-    await refreshAccountInfo(accountId, services_key.id, runtimeApi)
-
-    return published
-}
-
-async function refreshAccountInfo(accountId, keyId, runtimeApi) {
-    const currentBlockHeader = await runtimeApi.api.rpc.chain.getHeader()
-
-    // determine if we need to update onchain account
-    let currentInfo = await runtimeApi.discovery.getAccountInfo(accountId)
-
-    if (currentInfo == null ||
-        // change checking blockNumber so we refresh before expiery
-        currentBlockHeader.blockNumber.gt(currentInfo.expires_at) ||
-        currentInfo.identity.toString() !== keyId) {
-        debug('updating account info')
-        return runtimeApi.discovery.setAccountInfo(accountId, keyId, DEFAULT_LIFETIME)
-    }
+    return services_key.id;
 }
 
 module.exports = {


### PR DESCRIPTION
-  node publishes IPNS identity every 50 minutes and sets expiery in 60min, allowing network
to detect storage nodes being down earlier for better UX.
-  Syncing will start immediately rather than after sync run interval.
- [assets.createAndReturnStorageRelationship()](https://github.com/Joystream/storage-node-joystream/blob/development/packages/runtime-api/assets.js#L154) waits for events to get new relationship id, this wasn't happening and causing sync run to never complete. Fixed by restoring events handling to be before handing finalized transaction event. Not ideal, we should look into why it didn't work correctly specifically the event [matching code](https://github.com/Joystream/storage-node-joystream/blob/development/packages/runtime-api/index.js#L95)