### PR TITLE
Helios

### DIFF
--- a/packages/colossus/bin/cli.js
+++ b/packages/colossus/bin/cli.js
@@ -277,6 +277,10 @@ async function announce_public_url(api, config) {
     const expiresInBlocks = 600; // ~ 1 hour (6s block interval)
     await api.discovery.setAccountInfo(accountId, keyId, expiresInBlocks);
 
+    debug('publishing complete, scheduling next update')
+
+// >> sometimes after tx is finalized.. we are not reaching here!
+
     // Reannounce before expiery
     reannounce(50 * 60 * 1000); // in 50 minutes
 

--- a/packages/colossus/paths/asset/v0/{id}.js
+++ b/packages/colossus/paths/asset/v0/{id}.js
@@ -158,15 +158,20 @@ module.exports = function(config, storage, runtime)
               return;
             }
 
+            debug('accepting Content')
             await runtime.assets.acceptContent(role_addr, id);
 
+            debug('creating storage relationship for newly uploaded content')
             // Create storage relationship and flip it to ready.
             const dosr_id = await runtime.assets.createAndReturnStorageRelationship(role_addr, id);
+
+            debug('toggling storage relationship for newly uploaded content')
             await runtime.assets.toggleStorageRelationshipReady(role_addr, dosr_id, true);
 
             debug('Sending OK response.');
             res.status(200).send({ message: 'Asset uploaded.' });
           } catch (err) {
+            debug(`${err.message}`);
             error_handler(res, err);
           }
         });

--- a/packages/colossus/paths/discover/v0/{id}.js
+++ b/packages/colossus/paths/discover/v0/{id}.js
@@ -49,7 +49,7 @@ module.exports = function(config, runtime)
           }
 
         } catch (err) {
-          debug(`Error: ${err}`);
+          debug(`${err}`);
           res.status(400).end()
         }
     }

--- a/packages/discovery/discover.js
+++ b/packages/discovery/discover.js
@@ -1,12 +1,13 @@
 const axios = require('axios')
 const debug = require('debug')('discovery::discover')
-const AsyncLock = require('async-lock');
+
+var ipfs = require('ipfs-http-client')('localhost', '5001', { protocol: 'http' })
 
 function inBrowser() {
     return typeof window !== 'undefined'
 }
 
-const discoveryLock = new AsyncLock();
+var activeDiscoveries = {};
 var accountInfoCache = {};
 const CACHE_TTL = 60 * 60 * 1000;
 
@@ -71,14 +72,14 @@ async function discover_over_local_ipfs_node(actorAccountId, runtimeApi) {
 
     const ipns_address = `/ipns/${identity}/`
 
-    var ipfs = require('ipfs-http-client')('localhost', '5001', { protocol: 'http' })
-
+    debug('resolved ipns to ipfs object')
     let ipfs_name = await ipfs.name.resolve(ipns_address, {
         recursive: false, // there should only be one indirection to service info file
         nocache: false,
-    })
+    }) // this can hang forever!? can we set a timeout?
 
-    let data = await ipfs.get(ipfs_name)
+    debug('getting ipfs object', ipfs_name)
+    let data = await ipfs.get(ipfs_name) // this can sometimes hang forever!?! can we set a timeout?
 
     // there should only be one file published under the resolved path
     let content = data[0].content
@@ -92,48 +93,71 @@ async function discover_over_local_ipfs_node(actorAccountId, runtimeApi) {
 
 async function discover (actorAccountId, runtimeApi, useCachedValue = false, maxCacheAge = 0) {
     const id = actorAccountId.toString();
+    const cached = accountInfoCache[id];
 
-    return discoveryLock.acquire(id, async () => {
-        const cached = accountInfoCache[id];
-
-        if (cached && useCachedValue) {
-            if (maxCacheAge > 0) {
-                // get latest value
-                if (Date.now() > (cached.updated + maxCacheAge)) {
-                    return _discover(actorAccountId, runtimeApi);
-                }
+    if (cached && useCachedValue) {
+        if (maxCacheAge > 0) {
+            // get latest value
+            if (Date.now() > (cached.updated + maxCacheAge)) {
+                return _discover(actorAccountId, runtimeApi);
             }
-            // refresh if cache is stale, new value returned on next cached query
-            if (Date.now() > (cached.updated + CACHE_TTL)) {
-                _discover(actorAccountId, runtimeApi);
-            }
-            // return best known value
-            return cached.value;
-        } else {
-            return _discover(actorAccountId, runtimeApi);
         }
+        // refresh if cache is stale, new value returned on next cached query
+        if (Date.now() > (cached.updated + CACHE_TTL)) {
+            _discover(actorAccountId, runtimeApi);
+        }
+        // return best known value
+        return cached.value;
+    } else {
+        return _discover(actorAccountId, runtimeApi);
+    }
+}
+
+function createExternallyControlledPromise() {
+    let resolve, reject;
+    const promise = new Promise((_resolve, _reject) => {
+        resolve = _resolve;
+        reject = _reject;
     });
+    return ({ resolve, reject, promise });
 }
 
 async function _discover(actorAccountId, runtimeApi) {
-    let result = null;
+    const id = actorAccountId.toString();
 
+    const discoveryResult = activeDiscoveries[id];
+    if (discoveryResult) {
+        debug('discovery in progress waiting for result for',id);
+        return discoveryResult
+    }
+
+    debug('starting new discovery for', id);
+    const deferredDiscovery = createExternallyControlledPromise();
+    activeDiscoveries[id] = deferredDiscovery.promise;
+
+    let result;
     try {
         if (inBrowser()) {
             result = await discover_over_joystream_discovery_service(actorAccountId, runtimeApi)
         } else {
             result = await discover_over_local_ipfs_node(actorAccountId, runtimeApi)
         }
-
-        accountInfoCache[actorAccountId.toString()] = {
-            value: JSON.stringify(result),
+        debug(result)
+        result = JSON.stringify(result)
+        accountInfoCache[id] = {
+            value: result,
             updated: Date.now()
         };
+
+        deferredDiscovery.resolve(result);
+        delete activeDiscoveries[id];
+        return result;
     } catch (err) {
         debug(err.message);
+        deferredDiscovery.reject(err);
+        delete activeDiscoveries[id];
+        throw err;
     }
-
-    return result;
 }
 
 module.exports = {

--- a/packages/discovery/discover.js
+++ b/packages/discovery/discover.js
@@ -49,10 +49,10 @@ async function discover_over_joystream_discovery_service(actorAccountId, runtime
 
     if (!discoverApiEndpoint) {
         // TODO: get from bootstrap nodes, or discovered endpoints
-        discoverApiEndpoint = 'https://storage-node.joystream.org/discover/v0/'
+        discoverApiEndpoint = 'https://storage-node-1.joystream.org'
     }
 
-    const url = `${discoverApiEndpoint}/${actorAccountId}`
+    const url = `${discoverApiEndpoint}/discover/v0/${actorAccountId}`
 
     // should have parsed if data was json?
     const response = await axios.get(url)

--- a/packages/discovery/discover.js
+++ b/packages/discovery/discover.js
@@ -1,7 +1,7 @@
 const axios = require('axios')
 const debug = require('debug')('discovery::discover')
 
-var ipfs = require('ipfs-http-client')('localhost', '5001', { protocol: 'http' })
+const ipfs = require('ipfs-http-client')('localhost', '5001', { protocol: 'http' })
 
 function inBrowser() {
     return typeof window !== 'undefined'

--- a/packages/discovery/publish.js
+++ b/packages/discovery/publish.js
@@ -1,4 +1,6 @@
 const ipfsClient = require('ipfs-http-client')
+const ipfs = ipfsClient('localhost', '5001', { protocol: 'http' })
+
 const debug = require('debug')('discovery::publish')
 
 const SERVICES_KEY_NAME = 'services';
@@ -15,8 +17,6 @@ function encodeServiceInfo(info) {
 }
 
 async function publish (service_info) {
-    const ipfs = ipfsClient('localhost', '5001', { protocol: 'http' })
-
     const keys = await ipfs.key.list()
     let services_key = keys.find((key) => key.name === SERVICES_KEY_NAME)
 

--- a/packages/discovery/publish.js
+++ b/packages/discovery/publish.js
@@ -3,7 +3,7 @@ const ipfs = ipfsClient('localhost', '5001', { protocol: 'http' })
 
 const debug = require('debug')('discovery::publish')
 
-const SERVICES_KEY_NAME = 'services';
+const PUBLISH_KEY = 'self'; // 'services';
 
 function bufferFrom(data) {
     return Buffer.from(JSON.stringify(data), 'utf-8')
@@ -18,15 +18,19 @@ function encodeServiceInfo(info) {
 
 async function publish (service_info) {
     const keys = await ipfs.key.list()
-    let services_key = keys.find((key) => key.name === SERVICES_KEY_NAME)
+    let services_key = keys.find((key) => key.name === PUBLISH_KEY)
 
     // generate a new services key if not found
-    if (!services_key) {
+    if (PUBLISH_KEY !== 'self' && !services_key) {
         debug('generating ipns services key')
-        services_key = await ipfs.key.gen(SERVICES_KEY_NAME, {
+        services_key = await ipfs.key.gen(PUBLISH_KEY, {
           type: 'rsa',
           size: 2048
         });
+    }
+
+    if (!services_key) {
+        throw new Error('No IPFS publishing key available!')
     }
 
     debug('adding service info file to node')
@@ -34,7 +38,7 @@ async function publish (service_info) {
 
     debug('publishing...')
     const published = await ipfs.name.publish(files[0].hash, {
-        key: SERVICES_KEY_NAME,
+        key: PUBLISH_KEY,
         resolve: false,
         // lifetime: // string - Time duration of the record. Default: 24h
         // ttl:      // string - Time duration this record should be cached

--- a/packages/helios/.gitignore
+++ b/packages/helios/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+lib/
+

--- a/packages/helios/README.md
+++ b/packages/helios/README.md
@@ -1,0 +1,12 @@
+# Joystream Helios
+
+A basic tool to scan the joystream storage network to get a birds eye view of the health of the storage providers and content replication status.
+
+
+## Scanning
+
+```
+yarn
+yarn run helios
+```
+

--- a/packages/helios/bin/cli.js
+++ b/packages/helios/bin/cli.js
@@ -4,6 +4,7 @@ const { RuntimeApi } = require('@joystream/runtime-api');
 const { encodeAddress } = require('@polkadot/keyring')
 const { discover } = require('@joystream/discovery');
 const axios = require('axios');
+const stripEndingSlash = require('@joystream/util/stripEndingSlash');
 
 (async function main () {
 
@@ -72,7 +73,7 @@ const axios = require('axios');
       console.log('skipping', provider.address);
       return
     }
-    const swaggerUrl = `${removeEndingForwardSlash(provider.endpoint)}/swagger.json`;
+    const swaggerUrl = `${stripEndingSlash(provider.endpoint)}/swagger.json`;
     let error;
     try {
       await axios.get(swaggerUrl)
@@ -145,17 +146,8 @@ async function countContentAvailability(contentIds, source) {
 }
 
 function makeAssetUrl(contentId, source) {
-  source = removeEndingForwardSlash(source);
+  source = stripEndingSlash(source);
   return `${source}/asset/v0/${encodeAddress(contentId)}`
-}
-
-// return url with last `/` removed
-function removeEndingForwardSlash(url) {
-  let st = new String(url)
-  if (st.endsWith('/')) {
-    return st.substring(0, st.length - 1);
-  }
-  return st.toString()
 }
 
 async function assetRelationshipState(api, contentId, providers) {

--- a/packages/helios/bin/cli.js
+++ b/packages/helios/bin/cli.js
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+
+const { RuntimeApi } = require('@joystream/runtime-api');
+const { encodeAddress } = require('@polkadot/keyring')
+const { discover } = require('@joystream/discovery');
+const axios = require('axios');
+
+(async function main () {
+
+  const runtime = await RuntimeApi.create();
+  const api  = runtime.api;
+
+  // get current blockheight
+  const currentBlock = await api.rpc.chain.getHeader();
+  const currentHeight = currentBlock.blockNumber;
+
+  // get all providers
+  const storageProviders = await api.query.actors.accountIdsByRole(0);
+
+  const storageProviderAccountInfos = await Promise.all(storageProviders.map(async (account) => {
+    return ({
+      account,
+      info: await runtime.discovery.getAccountInfo(account),
+      joined: (await api.query.actors.actorByAccountId(account)).unwrap().joined_at
+    });
+  }));
+
+  const liveProviders = storageProviderAccountInfos.filter(({account, info}) => {
+    return info && info.expires_at.gte(currentHeight)
+  });
+
+  const downProviders = storageProviderAccountInfos.filter(({account, info}) => {
+    return info == null
+  });
+
+  const expiredTtlProviders = storageProviderAccountInfos.filter(({account, info}) => {
+    return info && currentHeight.gte(info.expires_at)
+  });
+
+  let providersStatuses = mapInfoToStatus(liveProviders, currentHeight);
+  console.log('\n== Live Providers\n', providersStatuses);
+
+  let expiredProviderStatuses = mapInfoToStatus(expiredTtlProviders, currentHeight)
+  console.log('\n== Expired Providers\n', expiredProviderStatuses);
+
+  // check when actor account was created consider grace period before removing
+  console.log('\n== Down Providers!\n', downProviders.map(provider => {
+    return ({
+      account: provider.account.toString(),
+      age: currentHeight.sub(provider.joined).toNumber()
+    })
+  }));
+
+  // Resolve IPNS identities of providers
+  console.log('\nResolving provider API Endpoints...')
+  providersStatuses = providersStatuses.concat(expiredProviderStatuses);
+  let endpoints = await Promise.all(providersStatuses.map(async (status) => {
+    try {
+      let serviceInfo = await discover.discover_over_joystream_discovery_service(status.address, runtime);
+      let info = JSON.parse(serviceInfo.serialized);
+      console.log(`${status.address} -> ${info.asset.endpoint}`);
+      return { address: status.address, endpoint: info.asset.endpoint};
+    } catch (err) {
+      console.log(err.message, 'failed resolving provider:', status.address)
+    }
+  }));
+
+  console.log('\nChecking API Endpoint is online')
+  await Promise.all(endpoints.map(async (provider) => {
+    const swaggerUrl = `${removeEndingForwardSlash(provider.endpoint)}/swagger.json`;
+    let error;
+    try {
+      await axios.get(swaggerUrl)
+    } catch (err) {error = err}
+    console.log(`${provider.endpoint} - ${error ? error.message : 'OK'}`);
+  }));
+
+  // after resolving for each resolved provider, HTTP HEAD with axios all known content ids
+  // report available/known
+  let knownContentIds = await runtime.assets.getKnownContentIds()
+
+  console.log(`\nContent Directory has ${knownContentIds.length} assets`);
+
+  await Promise.all(knownContentIds.map(async (contentId) => {
+    let [relationships, judgement] = await assetRelationshipState(api, contentId, storageProviders);
+    console.log(`${encodeAddress(contentId)} replication ${relationships}/${storageProviders.length} - ${judgement}`);
+  }));
+
+  console.log('\nChecking available assets on providers...');
+  endpoints.map(async ({address, endpoint}) => {
+    let count = await countContentAvailability(knownContentIds, endpoint);
+    console.log(`${address}: has ${count} assets`);
+  });
+
+  // interesting disconnect doesn't work unless an explicit provider was created
+  // for underlying api instance
+  runtime.api.disconnect();
+})();
+
+function mapInfoToStatus(providers, currentHeight) {
+  return providers.map(({account, info, joined}) => {
+    if (info) {
+      return {
+        address: account.toString(),
+        age: currentHeight.sub(joined).toNumber(),
+        identity: info.identity.toString(),
+        expiresIn: info.expires_at.sub(currentHeight).toNumber(),
+        expired: currentHeight.gte(info.expires_at),
+      }
+    } else {
+      return {
+        address: account.toString(),
+        identity: null,
+        status: 'down'
+      }
+    }
+  })
+}
+
+async function countContentAvailability(contentIds, source) {
+  let found = 0;
+  for(let i = 0; i < contentIds.length; i++) {
+    const assetUrl = makeAssetUrl(contentIds[i], source);
+    try {
+      await axios.head(assetUrl)
+      found++
+    } catch(err) { console.log(`${assetUrl} ${err.message}`); continue; }
+  }
+  return found;
+}
+
+function makeAssetUrl(contentId, source) {
+  source = removeEndingForwardSlash(source);
+  return `${source}/asset/v0/${encodeAddress(contentId)}`
+}
+
+// return url with last `/` removed
+function removeEndingForwardSlash(url) {
+  let st = new String(url)
+  if (st.endsWith('/')) {
+    return st.substring(0, st.length - 1);
+  }
+  return st.toString()
+}
+
+async function assetRelationshipState(api, contentId, providers) {
+  let dataObject = await api.query.dataDirectory.dataObjectByContentId(contentId);
+
+  // how many relationships out of active providers?
+  let relationshipIds = await api.query.dataObjectStorageRegistry.relationshipsByContentId(contentId);
+
+  let activeRelationships = await Promise.all(relationshipIds.map(async (id) => {
+    let relationship = await api.query.dataObjectStorageRegistry.relationships(id);
+    relationship = relationship.unwrap()
+    return providers.find((provider) => relationship.storage_provider.eq(provider))
+  }));
+
+  return [activeRelationships.filter(active => active).length, dataObject.unwrap().liaison_judgement]
+}

--- a/packages/helios/package.json
+++ b/packages/helios/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@joystream/helios",
+  "version": "0.1.0",
+  "bin": {
+    "helios": "bin/cli.js"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@joystream/runtime-api": "^0.1.0",
+    "@types/bn.js": "^4.11.5",
+    "axios": "^0.19.0",
+    "bn.js": "^4.11.8"
+  }
+}

--- a/packages/runtime-api/discovery.js
+++ b/packages/runtime-api/discovery.js
@@ -24,7 +24,7 @@ class DiscoveryApi
    * Get Bootstrap endpoints
    */
   async getBootstrapEndpoints() {
-    return this.base.api.query.discovery.bootstrap_endpoints()
+    return this.base.api.query.discovery.bootstrapEndpoints()
   }
 
   /*

--- a/packages/runtime-api/index.js
+++ b/packages/runtime-api/index.js
@@ -21,7 +21,7 @@
 const debug = require('debug')('joystream:runtime:base');
 
 const { registerJoystreamTypes } = require('@joystream/types');
-const { ApiPromise } = require('@polkadot/api');
+const { ApiPromise, WsProvider } = require('@polkadot/api');
 
 const { IdentitiesApi } = require('@joystream/runtime-api/identities');
 const { BalancesApi } = require('@joystream/runtime-api/balances');
@@ -51,8 +51,10 @@ class RuntimeApi
     // Register joystream types
     registerJoystreamTypes();
 
+    const provider = new WsProvider('ws://localhost:9944');
+
     // Create the API instrance
-    this.api = await ApiPromise.create();
+    this.api = await ApiPromise.create(provider);
 
     this.asyncLock = new AsyncLock();
 

--- a/packages/runtime-api/index.js
+++ b/packages/runtime-api/index.js
@@ -222,7 +222,7 @@ class RuntimeApi
               debug('TX Ready.');
               incrementNonce();
               resolve(unsubscribe); //releases lock
-            } else if (status.isBrodcast) {
+            } else if (status.isBroadcast) {
               debug('TX Broadcast.');
               incrementNonce();
               resolve(unsubscribe); //releases lock

--- a/packages/runtime-api/index.js
+++ b/packages/runtime-api/index.js
@@ -203,12 +203,17 @@ class RuntimeApi
             debug(`TX status: ${status.type}`);
 
             // Whatever events we get, process them if there's someone interested.
-            if (subscribed && callback) {
-              const matched = this._matchingEvents(subscribed, events);
-              debug('Matching events:', matched);
-              if (matched.length) {
-                callback(matched);
+            // It is critical that this event handling doesn't prevent
+            try {
+              if (subscribed && callback) {
+                const matched = this._matchingEvents(subscribed, events);
+                debug('Matching events:', matched);
+                if (matched.length) {
+                  callback(matched);
+                }
               }
+            } catch(err) {
+              debug(`Error handling events ${err.stack}`)
             }
 
             // We want to release lock as early as possible, sometimes Ready status

--- a/packages/util/stripEndingSlash.js
+++ b/packages/util/stripEndingSlash.js
@@ -1,0 +1,10 @@
+// return url with last `/` removed
+function removeEndingForwardSlash(url) {
+    let st = new String(url)
+    if (st.endsWith('/')) {
+        return st.substring(0, st.length - 1);
+    }
+    return st.toString()
+}
+
+module.exports = removeEndingForwardSlash

--- a/yarn.lock
+++ b/yarn.lock
@@ -625,6 +625,14 @@ axios@^0.18.0:
     follow-redirects "1.5.10"
     is-buffer "^2.0.2"
 
+axios@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
+  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
+  dependencies:
+    follow-redirects "1.5.10"
+    is-buffer "^2.0.2"
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"


### PR DESCRIPTION
- Helios - storage network status reporting tool
- Improved handling of concurrent request to discovery service
- Create one instance of IPFS client only for publishing. This should fix the problem that nodes at some point are no longer publishing identity successfully. (And either needing to restart node or ipfs daemon) edit: this was not the root cause but is a good fix nontheless
- Publish identity using the IPFS daemons 'self' key. This is same as key used for the PeerId. This allows us better diagnostics, by being able to ping and directly connect to a storage provider's IPFS node. eg. from command line:

```bash
$ ipfs ping QmSV83mZkvQj48VT6QRKguroBz6sgzxMEcwYrS7k25sZf6
PING QmSV83mZkvQj48VT6QRKguroBz6sgzxMEcwYrS7k25sZf6.
Pong received: time=105.73 ms
Pong received: time=120.77 ms
Pong received: time=99.78 ms
Pong received: time=100.20 ms
Pong received: time=109.02 ms
Pong received: time=105.05 ms
^C
Average latency: 106.76ms
```
- Fix typo in signAndSend() - was incorrectly detecting Broadcast status (which is one of the states when we unlock the nonce lock) If the Broadcast event was emitted but not the Ready event, it was resulting in a deadlock. (I still don't know why the Ready event doesn't always fire)