### PR TITLE
Report correct content file size in asset GET and HEAD requests

### DIFF
--- a/packages/storage/storage.js
+++ b/packages/storage/storage.js
@@ -293,10 +293,7 @@ class Storage
   async size(content_id, timeout)
   {
     const stat = await this.stat(content_id, timeout);
-    // FIXME CumulativeSize isn't correct - but it's the closest to a correct
-    //       size we're getting from IPFS. Returning this means we overestimate
-    //       Content-Length a little, which is better than underestimating it.
-    return stat.cumulativeSize;
+    return stat.size;
   }
 
   /*


### PR DESCRIPTION
Reported Content-Length was always larger than the real file size of the content being served, because cumulativeSize was being used. (see  https://github.com/ipfs/interface-js-ipfs-core/blob/master/SPEC/FILES.md#ipfsfilesstatpath-options-callback for details)

The problem was causing web media players to try to seek past the end of the file to get some extra metadata found at the end of the file (metadata for mp4 video files for example not formatted for faststart/web) and since they couldn't do that successfully some media files couldn't be played even though they were supported by the player.